### PR TITLE
Fix endpoint to omit default HTTPS port from generated URL

### DIFF
--- a/include/savanna/endpoint.hpp
+++ b/include/savanna/endpoint.hpp
@@ -60,7 +60,7 @@ namespace savanna
 			std::string new_url;
 			new_url += scheme() + "://";
 			new_url += host();
-			if (port() != 80) {
+			if (port() != 80 && port() != 443) {
 				new_url += ":" + std::to_string(port());
 			}
 			new_url += build_path();


### PR DESCRIPTION
This pull request makes a small but important improvement to the logic for reconstructing endpoint URLs. The change ensures that the port number is only included in the URL if it is not the default for HTTP (80) or HTTPS (443). This results in cleaner and more standard URLs.